### PR TITLE
Fix Chip and FlowMeter if names are qualified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.3.3
+
+- Fix `Chip` and `FlowMeter` when their type names would be qualified (https://github.com/mpimd-csc/MORWiki.jl/pull/6)
+
 # v0.3.2
 
 - Fix Julia 1.6 (https://github.com/mpimd-csc/MORWiki.jl/pull/5)

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MORWiki"
 uuid = "4add22a6-c4b7-49d8-833a-0e1707ec89d0"
 authors = ["Jonas Schulze <jschulze@mpi-magdeburg.mpg.de> and contributors"]
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"

--- a/src/oberwolfach/ctf.jl
+++ b/src/oberwolfach/ctf.jl
@@ -93,7 +93,7 @@ struct FlowMeter <: ConvectiveThermalFlow
 end
 
 function assemble(ctf::ConvectiveThermalFlow)
-    kind = string(typeof(ctf))
+    kind = string(nameof(typeof(ctf)))
     @unpack dep, suffix = VARIANTS_ctf[kind][ctf.velocity]
     dir = @datadep_str dep
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,4 +38,10 @@ end
     @testset "Data consistency" begin
         @test typeof(fos) === typeof(assemble(FenicsRail(371)))
     end
+
+    @testset "Qualified benchmark names" begin
+        @assert !@isdefined(Chip)
+        fos = assemble(MORWiki.Chip(0.0))
+        @test fos isa MORWiki.FirstOrderSystem
+    end
 end


### PR DESCRIPTION
If their type names resolve to MORWiki.{Chip,FlowMeter} when being converted to a string, e.g., if the user decided against importing these benchmarks, trying to assemble these benchmarks would otherwise lead to a KeyError.

I discovered this error trying to load the benchmark within a Pluto notebook (v0.20.6), despite `using MORWiki: Chip`, and I do not understand why. However, this issue is worth fixing anyway.